### PR TITLE
updates for known folks

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,9 @@
         mermaid.initialize({startOnLoad:true,theme:'neutral'})
         await mermaid.run({querySelector:'code.language-mermaid'})
     </script>
+    {% for module in page.modules %}
+    <script src="{{ module }}" type="module"></script>
+    {% endfor %}
     <link rel="stylesheet" href="{{ "/assets/css/main.css?v=" | append: site.github.build_revision | relative_url }}">
     <!--[if lt IE 9]>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -133,6 +133,24 @@ h3 {
     grid-area: excerpt;
     margin: 1em;
 }
+.hidden {
+    display: none;
+}
+a.button {
+    background-color: var(--primary-color);
+    color           : var(--white);
+    padding         : 0.5em 1em;
+    text-decoration  : none;
+    font-size       : 1.2em;
+    border-radius    : 5px;
+    box-shadow       : 0 0 3px var(--darkest);
+    transition       : all .2s ease-in-out;
+}
+a.button:hover {
+    background-color: var(--primary-light);
+    color           : var(--darkest);
+    box-shadow      : 0 0 3px var(--white);
+}   
 
 .wrapper {
     min-height: 100vh;
@@ -243,7 +261,22 @@ dd {
     width                : 100%;
 }
 
-.gridly>div {
+.gridly>li {
+    list-style: none;
+    padding   : 1em;
+    margin    : 0;
+}
+.gridly>li>a {
+    text-decoration: none;
+    color: var(--white);
+    transition: all .2s ease-in-out;
+}
+
+.gridly>li>a:hover {
+    color: var(--primary-light);
+}
+
+.gridly>* {
     background-color: var(--darkest);
     padding         : 1em;
 }

--- a/assets/js/isKnown.js
+++ b/assets/js/isKnown.js
@@ -1,0 +1,16 @@
+import TPEN from "https://app.t-pen.org/api/TPEN.js"
+
+const token = new URLSearchParams(location.search).get("idToken") ?? TPEN.getAuthorization()
+history.replaceState(null, "", location.pathname + location.search.replace(/[\?&]idToken=[^&]+/, ''))
+
+if (token) {
+    document.querySelectorAll(".unauthenticated").forEach(el=>el.classList.add("hidden"))
+    document.querySelectorAll(".authenticated").forEach(el=>el.classList.remove("hidden"))
+    TPEN.getUserProjects(token).then((projects) => {
+        const projectsList = document.querySelector(".project-list")
+        if(projectsList) {
+            projectsList.innerHTML = projects.map(project => `<li><a href="https://app.t-pen.org/project/?projectID=${project._id}" target="_blank">${project.label ?? project.title}</a></li>`).join("")
+            projectsList.classList.remove("hidden")
+        }
+    })
+}

--- a/pages/index.md
+++ b/pages/index.md
@@ -2,13 +2,18 @@
 layout: default
 title: TPEN
 permalink: /
+modules: [/assets/js/isKnown.js]
 ---
 > `This site is scheduled for launch in 2026 and not intended for public use at this time.`{: .notice}
 
 ## Transcription for Paleographical and Editorial Notation
 
-<button role="button"> Log in </button>
+{: .unauthenticated}
+[Signup](./login?returnTo={{site.url}}){: .button role="button"}
 Open an account to start recording annotations on images from all over the world and across time.
+
+{: .authenticated.hidden}
+Welcome back! [Launch TPEN 3.0](https://app.t-pen.org){: .button role="button"}
 
 ---
 {% assign today_date = 'now' | date: '%s' %}
@@ -74,7 +79,14 @@ Established in 2010, the project is still active and growing.
 
 ## Transcribe Now
 
-Open your account to get started: <button role="button"> Log in </button>
+{: .unauthenticated}
+Open your account to get started: [Login](./login?returnTo={{site.url}}){: .button role="button"}
+
+{: .authenticated.hidden}
+Head over to the TPEN app to work on any of your projects:
+
+{: .project-list.hidden.gridly}
+Your projects
 
 ---
 
@@ -99,7 +111,7 @@ Share your Project in a readonly viewer
 
 ---
 
-![old TPEN logo]({{site.baseurl}}/assets/img/tpen_clearShadowSmall.png)
+![old TPEN logo]({{site.baseurl}}assets/img/tpen_clearShadowSmall.png)
 This tool is the evolution of the 21st century transcription platform at [t‑pen.org](https://t-pen.org).
 Originally targeting Medieval manuscripts, users have fostered a community of carefully
 transcribed images of scripts, engravings, and calligraphy from all over the world across time.


### PR DESCRIPTION
fixes #50
fixes #51

- default layout loads modules
- index loads isKnown.js module
- index shows list of projects from token

In markdown, the default layout allows for frontmatter `modules: [ ]`. If you load "isKnown.js" from our js directory, it will look for the `userToken` and then update the rendered page:

* `.unauthenticated` elements have `.hidden` added while `.authenticated` ones have it removed
* `project-list` element is updated and unhidden once the projects from the token load.

In this kramdown flavor, you class things with `{: .className}` at the end. For paragraphs, this may need to be on its own line

```markdown
...some other content.

{: .unauthenticated}
This content will disappear if there is a known user.

{: .authenticated.hidden}
This will appear once there is a known user.

{: .project-list.hidden}
After a known user has projects loaded, this will be replaced with a set of <li> elements containing the title of the project and a link to its generic page in app.t-pen.org.

## Regular Markdown continues
```

