### PR TITLE
Signup button

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -11,7 +11,7 @@ modules: [/assets/js/isKnown.js]
 ## Transcription for Paleographical and Editorial Notation
 
 {: .unauthenticated}
-[Signup](./login?returnTo={{site.url}}){: .button role="button"}
+[Signup](./login?returnTo={{site.url}}/roadmap){: .button role="button"}
 Open an account to start recording annotations on images from all over the world and across time.
 
 {: .authenticated.hidden}


### PR DESCRIPTION
We could have this button redirect back into interfaces instead of /roadmap with.  
`[Signup](./login?returnTo=https://app.t-pen.org){: .button role="button"}`

This is what you need to make it work just like the 'Sign up as a pilot user today!' in the notice.